### PR TITLE
Import individual icons

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -1,9 +1,12 @@
 import Vue from 'vue'; // eslint-disable-line
 import fontawesome from '@fortawesome/fontawesome';
 import FontAwesomeIcon from '@fortawesome/vue-fontawesome';
+
 <% options.packs.forEach(({package, icons}) => { %>
   <% if (icons) { %>
-    import  { <%=icons.join(',')%> } from '<%=package%>';
+    <% icons.forEach((icon) => { %>
+      import <%=icon%> from '<%=package%>/<%=icon%>';
+    <% }) %>
   <% } else { %>
     import <%=package.split(/[\s\/]+/)[1].replace(/-/g, "")%> from '<%=package%>';
   <% } %>


### PR DESCRIPTION
When icons are defined for a package, imports them individually instead of getting them from the package.

This change reduces the size of the resulting bundle drastically :sparkles: